### PR TITLE
Change tree to graph

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,9 @@ numpy = "*"
 pysimplegui = "*"
 networkx = "*"
 matplotlib = "*"
+pydot = "*"
+graphviz = "*"
+scipy = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,8 @@ name = "pypi"
 pandas = "*"
 numpy = "*"
 pysimplegui = "*"
+networkx = "*"
+matplotlib = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b1d3a4e72b1467f44e888725e3d4cf17667cf084381f3159c3b82298ed74baa9"
+            "sha256": "f19ff89434a7abd2ca8a4ae89343371dc7f1ed5b3a5538eaca497d4b924737d4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,39 +16,267 @@
         ]
     },
     "default": {
-        "numpy": {
+        "contourpy": {
             "hashes": [
-                "sha256:0fe563fc8ed9dc4474cbf70742673fc4391d70f4363f917599a7fa99f042d5a8",
-                "sha256:12ac457b63ec8ded85d85c1e17d85efd3c2b0967ca39560b307a35a6703a4735",
-                "sha256:2341f4ab6dba0834b685cce16dad5f9b6606ea8a00e6da154f5dbded70fdc4dd",
-                "sha256:296d17aed51161dbad3c67ed6d164e51fcd18dbcd5dd4f9d0a9c6055dce30810",
-                "sha256:488a66cb667359534bc70028d653ba1cf307bae88eab5929cd707c761ff037db",
-                "sha256:4d52914c88b4930dafb6c48ba5115a96cbab40f45740239d9f4159c4ba779962",
-                "sha256:5e13030f8793e9ee42f9c7d5777465a560eb78fa7e11b1c053427f2ccab90c79",
-                "sha256:61be02e3bf810b60ab74e81d6d0d36246dbfb644a462458bb53b595791251911",
-                "sha256:7607b598217745cc40f751da38ffd03512d33ec06f3523fb0b5f82e09f6f676d",
-                "sha256:7a70a7d3ce4c0e9284e92285cba91a4a3f5214d87ee0e95928f3614a256a1488",
-                "sha256:7ab46e4e7ec63c8a5e6dbf5c1b9e1c92ba23a7ebecc86c336cb7bf3bd2fb10e5",
-                "sha256:8981d9b5619569899666170c7c9748920f4a5005bf79c72c07d08c8a035757b0",
-                "sha256:8c053d7557a8f022ec823196d242464b6955a7e7e5015b719e76003f63f82d0f",
-                "sha256:926db372bc4ac1edf81cfb6c59e2a881606b409ddc0d0920b988174b2e2a767f",
-                "sha256:95d79ada05005f6f4f337d3bb9de8a7774f259341c70bc88047a1f7b96a4bcb2",
-                "sha256:95de7dc7dc47a312f6feddd3da2500826defdccbc41608d0031276a24181a2c0",
-                "sha256:a0882323e0ca4245eb0a3d0a74f88ce581cc33aedcfa396e415e5bba7bf05f68",
-                "sha256:a8365b942f9c1a7d0f0dc974747d99dd0a0cdfc5949a33119caf05cb314682d3",
-                "sha256:a8aae2fb3180940011b4862b2dd3756616841c53db9734b27bb93813cd79fce6",
-                "sha256:c237129f0e732885c9a6076a537e974160482eab8f10db6292e92154d4c67d71",
-                "sha256:c67b833dbccefe97cdd3f52798d430b9d3430396af7cdb2a0c32954c3ef73894",
-                "sha256:ce03305dd694c4873b9429274fd41fc7eb4e0e4dea07e0af97a933b079a5814f",
-                "sha256:d331afac87c92373826af83d2b2b435f57b17a5c74e6268b79355b970626e329",
-                "sha256:dada341ebb79619fe00a291185bba370c9803b1e1d7051610e01ed809ef3a4ba",
-                "sha256:ed2cc92af0efad20198638c69bb0fc2870a58dabfba6eb722c933b48556c686c",
-                "sha256:f260da502d7441a45695199b4e7fd8ca87db659ba1c78f2bbf31f934fe76ae0e",
-                "sha256:f2f390aa4da44454db40a1f0201401f9036e8d578a25f01a6e237cea238337ef",
-                "sha256:f76025acc8e2114bb664294a07ede0727aa75d63a06d2fae96bf29a81747e4a7"
+                "sha256:0236875c5a0784215b49d00ebbe80c5b6b5d5244b3655a36dda88105334dea17",
+                "sha256:03d1b9c6b44a9e30d554654c72be89af94fab7510b4b9f62356c64c81cec8b7d",
+                "sha256:0537cc1195245bbe24f2913d1f9211b8f04eb203de9044630abd3664c6cc339c",
+                "sha256:06ca79e1efbbe2df795822df2fa173d1a2b38b6e0f047a0ec7903fbca1d1847e",
+                "sha256:08e8d09d96219ace6cb596506fb9b64ea5f270b2fb9121158b976d88871fcfd1",
+                "sha256:0b1e66346acfb17694d46175a0cea7d9036f12ed0c31dfe86f0f405eedde2bdd",
+                "sha256:0b97454ed5b1368b66ed414c754cba15b9750ce69938fc6153679787402e4cdf",
+                "sha256:0e4854cc02006ad6684ce092bdadab6f0912d131f91c2450ce6dbdea78ee3c0b",
+                "sha256:12a7dc8439544ed05c6553bf026d5e8fa7fad48d63958a95d61698df0e00092b",
+                "sha256:1b1ee48a130da4dd0eb8055bbab34abf3f6262957832fd575e0cab4979a15a41",
+                "sha256:1c0e1308307a75e07d1f1b5f0f56b5af84538a5e9027109a7bcf6cb47c434e72",
+                "sha256:1dedf4c64185a216c35eb488e6f433297c660321275734401760dafaeb0ad5c2",
+                "sha256:208bc904889c910d95aafcf7be9e677726df9ef71e216780170dbb7e37d118fa",
+                "sha256:211dfe2bd43bf5791d23afbe23a7952e8ac8b67591d24be3638cabb648b3a6eb",
+                "sha256:341330ed19074f956cb20877ad8d2ae50e458884bfa6a6df3ae28487cc76c768",
+                "sha256:344cb3badf6fc7316ad51835f56ac387bdf86c8e1b670904f18f437d70da4183",
+                "sha256:358f6364e4873f4d73360b35da30066f40387dd3c427a3e5432c6b28dd24a8fa",
+                "sha256:371f6570a81dfdddbb837ba432293a63b4babb942a9eb7aaa699997adfb53278",
+                "sha256:375d81366afd547b8558c4720337218345148bc2fcffa3a9870cab82b29667f2",
+                "sha256:3a1917d3941dd58732c449c810fa7ce46cc305ce9325a11261d740118b85e6f3",
+                "sha256:4081918147fc4c29fad328d5066cfc751da100a1098398742f9f364be63803fc",
+                "sha256:444fb776f58f4906d8d354eb6f6ce59d0a60f7b6a720da6c1ccb839db7c80eb9",
+                "sha256:46deb310a276cc5c1fd27958e358cce68b1e8a515fa5a574c670a504c3a3fe30",
+                "sha256:494efed2c761f0f37262815f9e3c4bb9917c5c69806abdee1d1cb6611a7174a0",
+                "sha256:50627bf76abb6ba291ad08db583161939c2c5fab38c38181b7833423ab9c7de3",
+                "sha256:5641927cc5ae66155d0c80195dc35726eae060e7defc18b7ab27600f39dd1fe7",
+                "sha256:5b117d29433fc8393b18a696d794961464e37afb34a6eeb8b2c37b5f4128a83e",
+                "sha256:613c665529899b5d9fade7e5d1760111a0b011231277a0d36c49f0d3d6914bd6",
+                "sha256:6e459ebb8bb5ee4c22c19cc000174f8059981971a33ce11e17dddf6aca97a142",
+                "sha256:6f56515e7c6fae4529b731f6c117752247bef9cdad2b12fc5ddf8ca6a50965a5",
+                "sha256:730c27978a0003b47b359935478b7d63fd8386dbb2dcd36c1e8de88cbfc1e9de",
+                "sha256:75a2e638042118118ab39d337da4c7908c1af74a8464cad59f19fbc5bbafec9b",
+                "sha256:78ced51807ccb2f45d4ea73aca339756d75d021069604c2fccd05390dc3c28eb",
+                "sha256:7ee394502026d68652c2824348a40bf50f31351a668977b51437131a90d777ea",
+                "sha256:8468b40528fa1e15181cccec4198623b55dcd58306f8815a793803f51f6c474a",
+                "sha256:84c593aeff7a0171f639da92cb86d24954bbb61f8a1b530f74eb750a14685832",
+                "sha256:913bac9d064cff033cf3719e855d4f1db9f1c179e0ecf3ba9fdef21c21c6a16a",
+                "sha256:9447c45df407d3ecb717d837af3b70cfef432138530712263730783b3d016512",
+                "sha256:9b0e7fe7f949fb719b206548e5cde2518ffb29936afa4303d8a1c4db43dcb675",
+                "sha256:9bc407a6af672da20da74823443707e38ece8b93a04009dca25856c2d9adadb1",
+                "sha256:9e8e686a6db92a46111a1ee0ee6f7fbfae4048f0019de207149f43ac1812cf95",
+                "sha256:9fc4e7973ed0e1fe689435842a6e6b330eb7ccc696080dda9a97b1a1b78e41db",
+                "sha256:a457ee72d9032e86730f62c5eeddf402e732fdf5ca8b13b41772aa8ae13a4563",
+                "sha256:a628bba09ba72e472bf7b31018b6281fd4cc903f0888049a3724afba13b6e0b8",
+                "sha256:a79d239fc22c3b8d9d3de492aa0c245533f4f4c7608e5749af866949c0f1b1b9",
+                "sha256:aa4674cf3fa2bd9c322982644967f01eed0c91bb890f624e0e0daf7a5c3383e9",
+                "sha256:acd2bd02f1a7adff3a1f33e431eb96ab6d7987b039d2946a9b39fe6fb16a1036",
+                "sha256:b3b1bd7577c530eaf9d2bc52d1a93fef50ac516a8b1062c3d1b9bcec9ebe329b",
+                "sha256:b48d94386f1994db7c70c76b5808c12e23ed7a4ee13693c2fc5ab109d60243c0",
+                "sha256:b64f747e92af7da3b85631a55d68c45a2d728b4036b03cdaba4bd94bcc85bd6f",
+                "sha256:b98c820608e2dca6442e786817f646d11057c09a23b68d2b3737e6dcb6e4a49b",
+                "sha256:c1baa49ab9fedbf19d40d93163b7d3e735d9cd8d5efe4cce9907902a6dad391f",
+                "sha256:c38c6536c2d71ca2f7e418acaf5bca30a3af7f2a2fa106083c7d738337848dbe",
+                "sha256:c78bfbc1a7bff053baf7e508449d2765964d67735c909b583204e3240a2aca45",
+                "sha256:cd2bc0c8f2e8de7dd89a7f1c10b8844e291bca17d359373203ef2e6100819edd",
+                "sha256:d2eff2af97ea0b61381828b1ad6cd249bbd41d280e53aea5cccd7b2b31b8225c",
+                "sha256:d8834c14b8c3dd849005e06703469db9bf96ba2d66a3f88ecc539c9a8982e0ee",
+                "sha256:d912f0154a20a80ea449daada904a7eb6941c83281a9fab95de50529bfc3a1da",
+                "sha256:da1ef35fd79be2926ba80fbb36327463e3656c02526e9b5b4c2b366588b74d9a",
+                "sha256:dbe6fe7a1166b1ddd7b6d887ea6fa8389d3f28b5ed3f73a8f40ece1fc5a3d340",
+                "sha256:dcd556c8fc37a342dd636d7eef150b1399f823a4462f8c968e11e1ebeabee769",
+                "sha256:e13b31d1b4b68db60b3b29f8e337908f328c7f05b9add4b1b5c74e0691180109",
+                "sha256:e1739496c2f0108013629aa095cc32a8c6363444361960c07493818d0dea2da4",
+                "sha256:e43255a83835a129ef98f75d13d643844d8c646b258bebd11e4a0975203e018f",
+                "sha256:e626cefff8491bce356221c22af5a3ea528b0b41fbabc719c00ae233819ea0bf",
+                "sha256:eadad75bf91897f922e0fb3dca1b322a58b1726a953f98c2e5f0606bd8408621",
+                "sha256:f33da6b5d19ad1bb5e7ad38bb8ba5c426d2178928bc2b2c44e8823ea0ecb6ff3",
+                "sha256:f4052a8a4926d4468416fc7d4b2a7b2a3e35f25b39f4061a7e2a3a2748c4fc48",
+                "sha256:f6ca38dd8d988eca8f07305125dec6f54ac1c518f1aaddcc14d08c01aebb6efc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.6"
+        },
+        "cycler": {
+            "hashes": [
+                "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3",
+                "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.11.0"
+        },
+        "fonttools": {
+            "hashes": [
+                "sha256:2bb244009f9bf3fa100fc3ead6aeb99febe5985fa20afbfbaa2f8946c2fbdaf1",
+                "sha256:820466f43c8be8c3009aef8b87e785014133508f0de64ec469e4efb643ae54fb"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.38.0"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:02f79693ec433cb4b5f51694e8477ae83b3205768a6fb48ffba60549080e295b",
+                "sha256:03baab2d6b4a54ddbb43bba1a3a2d1627e82d205c5cf8f4c924dc49284b87166",
+                "sha256:1041feb4cda8708ce73bb4dcb9ce1ccf49d553bf87c3954bdfa46f0c3f77252c",
+                "sha256:10ee06759482c78bdb864f4109886dff7b8a56529bc1609d4f1112b93fe6423c",
+                "sha256:1d1573129aa0fd901076e2bfb4275a35f5b7aa60fbfb984499d661ec950320b0",
+                "sha256:283dffbf061a4ec60391d51e6155e372a1f7a4f5b15d59c8505339454f8989e4",
+                "sha256:28bc5b299f48150b5f822ce68624e445040595a4ac3d59251703779836eceff9",
+                "sha256:2a66fdfb34e05b705620dd567f5a03f239a088d5a3f321e7b6ac3239d22aa286",
+                "sha256:2e307eb9bd99801f82789b44bb45e9f541961831c7311521b13a6c85afc09767",
+                "sha256:2e407cb4bd5a13984a6c2c0fe1845e4e41e96f183e5e5cd4d77a857d9693494c",
+                "sha256:2f5e60fabb7343a836360c4f0919b8cd0d6dbf08ad2ca6b9cf90bf0c76a3c4f6",
+                "sha256:36dafec3d6d6088d34e2de6b85f9d8e2324eb734162fba59d2ba9ed7a2043d5b",
+                "sha256:3fe20f63c9ecee44560d0e7f116b3a747a5d7203376abeea292ab3152334d004",
+                "sha256:41dae968a94b1ef1897cb322b39360a0812661dba7c682aa45098eb8e193dbdf",
+                "sha256:4bd472dbe5e136f96a4b18f295d159d7f26fd399136f5b17b08c4e5f498cd494",
+                "sha256:4ea39b0ccc4f5d803e3337dd46bcce60b702be4d86fd0b3d7531ef10fd99a1ac",
+                "sha256:5853eb494c71e267912275e5586fe281444eb5e722de4e131cddf9d442615626",
+                "sha256:5bce61af018b0cb2055e0e72e7d65290d822d3feee430b7b8203d8a855e78766",
+                "sha256:6295ecd49304dcf3bfbfa45d9a081c96509e95f4b9d0eb7ee4ec0530c4a96514",
+                "sha256:62ac9cc684da4cf1778d07a89bf5f81b35834cb96ca523d3a7fb32509380cbf6",
+                "sha256:70e7c2e7b750585569564e2e5ca9845acfaa5da56ac46df68414f29fea97be9f",
+                "sha256:7577c1987baa3adc4b3c62c33bd1118c3ef5c8ddef36f0f2c950ae0b199e100d",
+                "sha256:75facbe9606748f43428fc91a43edb46c7ff68889b91fa31f53b58894503a191",
+                "sha256:787518a6789009c159453da4d6b683f468ef7a65bbde796bcea803ccf191058d",
+                "sha256:78d6601aed50c74e0ef02f4204da1816147a6d3fbdc8b3872d263338a9052c51",
+                "sha256:7c43e1e1206cd421cd92e6b3280d4385d41d7166b3ed577ac20444b6995a445f",
+                "sha256:81e38381b782cc7e1e46c4e14cd997ee6040768101aefc8fa3c24a4cc58e98f8",
+                "sha256:841293b17ad704d70c578f1f0013c890e219952169ce8a24ebc063eecf775454",
+                "sha256:872b8ca05c40d309ed13eb2e582cab0c5a05e81e987ab9c521bf05ad1d5cf5cb",
+                "sha256:877272cf6b4b7e94c9614f9b10140e198d2186363728ed0f701c6eee1baec1da",
+                "sha256:8c808594c88a025d4e322d5bb549282c93c8e1ba71b790f539567932722d7bd8",
+                "sha256:8ed58b8acf29798b036d347791141767ccf65eee7f26bde03a71c944449e53de",
+                "sha256:91672bacaa030f92fc2f43b620d7b337fd9a5af28b0d6ed3f77afc43c4a64b5a",
+                "sha256:968f44fdbf6dd757d12920d63b566eeb4d5b395fd2d00d29d7ef00a00582aac9",
+                "sha256:9f85003f5dfa867e86d53fac6f7e6f30c045673fa27b603c397753bebadc3008",
+                "sha256:a553dadda40fef6bfa1456dc4be49b113aa92c2a9a9e8711e955618cd69622e3",
+                "sha256:a68b62a02953b9841730db7797422f983935aeefceb1679f0fc85cbfbd311c32",
+                "sha256:abbe9fa13da955feb8202e215c4018f4bb57469b1b78c7a4c5c7b93001699938",
+                "sha256:ad881edc7ccb9d65b0224f4e4d05a1e85cf62d73aab798943df6d48ab0cd79a1",
+                "sha256:b1792d939ec70abe76f5054d3f36ed5656021dcad1322d1cc996d4e54165cef9",
+                "sha256:b428ef021242344340460fa4c9185d0b1f66fbdbfecc6c63eff4b7c29fad429d",
+                "sha256:b533558eae785e33e8c148a8d9921692a9fe5aa516efbdff8606e7d87b9d5824",
+                "sha256:ba59c92039ec0a66103b1d5fe588fa546373587a7d68f5c96f743c3396afc04b",
+                "sha256:bc8d3bd6c72b2dd9decf16ce70e20abcb3274ba01b4e1c96031e0c4067d1e7cd",
+                "sha256:bc9db8a3efb3e403e4ecc6cd9489ea2bac94244f80c78e27c31dcc00d2790ac2",
+                "sha256:bf7d9fce9bcc4752ca4a1b80aabd38f6d19009ea5cbda0e0856983cf6d0023f5",
+                "sha256:c2dbb44c3f7e6c4d3487b31037b1bdbf424d97687c1747ce4ff2895795c9bf69",
+                "sha256:c79ebe8f3676a4c6630fd3f777f3cfecf9289666c84e775a67d1d358578dc2e3",
+                "sha256:c97528e64cb9ebeff9701e7938653a9951922f2a38bd847787d4a8e498cc83ae",
+                "sha256:d0611a0a2a518464c05ddd5a3a1a0e856ccc10e67079bb17f265ad19ab3c7597",
+                "sha256:d06adcfa62a4431d404c31216f0f8ac97397d799cd53800e9d3efc2fbb3cf14e",
+                "sha256:d41997519fcba4a1e46eb4a2fe31bc12f0ff957b2b81bac28db24744f333e955",
+                "sha256:d5b61785a9ce44e5a4b880272baa7cf6c8f48a5180c3e81c59553ba0cb0821ca",
+                "sha256:da152d8cdcab0e56e4f45eb08b9aea6455845ec83172092f09b0e077ece2cf7a",
+                "sha256:da7e547706e69e45d95e116e6939488d62174e033b763ab1496b4c29b76fabea",
+                "sha256:db5283d90da4174865d520e7366801a93777201e91e79bacbac6e6927cbceede",
+                "sha256:db608a6757adabb32f1cfe6066e39b3706d8c3aa69bbc353a5b61edad36a5cb4",
+                "sha256:e0ea21f66820452a3f5d1655f8704a60d66ba1191359b96541eaf457710a5fc6",
+                "sha256:e7da3fec7408813a7cebc9e4ec55afed2d0fd65c4754bc376bf03498d4e92686",
+                "sha256:e92a513161077b53447160b9bd8f522edfbed4bd9759e4c18ab05d7ef7e49408",
+                "sha256:ecb1fa0db7bf4cff9dac752abb19505a233c7f16684c5826d1f11ebd9472b871",
+                "sha256:efda5fc8cc1c61e4f639b8067d118e742b812c930f708e6667a5ce0d13499e29",
+                "sha256:f0a1dbdb5ecbef0d34eb77e56fcb3e95bbd7e50835d9782a45df81cc46949750",
+                "sha256:f0a71d85ecdd570ded8ac3d1c0f480842f49a40beb423bb8014539a9f32a5897",
+                "sha256:f4f270de01dd3e129a72efad823da90cc4d6aafb64c410c9033aba70db9f1ff0",
+                "sha256:f6cb459eea32a4e2cf18ba5fcece2dbdf496384413bc1bae15583f19e567f3b2",
+                "sha256:f8ad8285b01b0d4695102546b342b493b3ccc6781fc28c8c6a1bb63e95d22f09",
+                "sha256:f9f39e2f049db33a908319cf46624a569b36983c7c78318e9726a4cb8923b26c"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.4.4"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:0844523dfaaff566e39dbfa74e6f6dc42e92f7a365ce80929c5030b84caa563a",
+                "sha256:0eda9d1b43f265da91fb9ae10d6922b5a986e2234470a524e6b18f14095b20d2",
+                "sha256:168093410b99f647ba61361b208f7b0d64dde1172b5b1796d765cd243cadb501",
+                "sha256:1836f366272b1557a613f8265db220eb8dd883202bbbabe01bad5a4eadfd0c95",
+                "sha256:19d61ee6414c44a04addbe33005ab1f87539d9f395e25afcbe9a3c50ce77c65c",
+                "sha256:252957e208c23db72ca9918cb33e160c7833faebf295aaedb43f5b083832a267",
+                "sha256:32d29c8c26362169c80c5718ce367e8c64f4dd068a424e7110df1dd2ed7bd428",
+                "sha256:380d48c15ec41102a2b70858ab1dedfa33eb77b2c0982cb65a200ae67a48e9cb",
+                "sha256:3964934731fd7a289a91d315919cf757f293969a4244941ab10513d2351b4e83",
+                "sha256:3cef89888a466228fc4e4b2954e740ce8e9afde7c4315fdd18caa1b8de58ca17",
+                "sha256:4426c74761790bff46e3d906c14c7aab727543293eed5a924300a952e1a3a3c1",
+                "sha256:5024b8ed83d7f8809982d095d8ab0b179bebc07616a9713f86d30cf4944acb73",
+                "sha256:52c2bdd7cd0bf9d5ccdf9c1816568fd4ccd51a4d82419cc5480f548981b47dd0",
+                "sha256:54fa9fe27f5466b86126ff38123261188bed568c1019e4716af01f97a12fe812",
+                "sha256:5ba73aa3aca35d2981e0b31230d58abb7b5d7ca104e543ae49709208d8ce706a",
+                "sha256:5e16dcaecffd55b955aa5e2b8a804379789c15987e8ebd2f32f01398a81e975b",
+                "sha256:5ecfc6559132116dedfc482d0ad9df8a89dc5909eebffd22f3deb684132d002f",
+                "sha256:74153008bd24366cf099d1f1e83808d179d618c4e32edb0d489d526523a94d9f",
+                "sha256:78ec3c3412cf277e6252764ee4acbdbec6920cc87ad65862272aaa0e24381eee",
+                "sha256:795ad83940732b45d39b82571f87af0081c120feff2b12e748d96bb191169e33",
+                "sha256:7f716b6af94dc1b6b97c46401774472f0867e44595990fe80a8ba390f7a0a028",
+                "sha256:83dc89c5fd728fdb03b76f122f43b4dcee8c61f1489e232d9ad0f58020523e1c",
+                "sha256:8a0ae37576ed444fe853709bdceb2be4c7df6f7acae17b8378765bd28e61b3ae",
+                "sha256:8a8dbe2cb7f33ff54b16bb5c500673502a35f18ac1ed48625e997d40c922f9cc",
+                "sha256:8a9d899953c722b9afd7e88dbefd8fb276c686c3116a43c577cfabf636180558",
+                "sha256:8d0068e40837c1d0df6e3abf1cdc9a34a6d2611d90e29610fa1d2455aeb4e2e5",
+                "sha256:9347cc6822f38db2b1d1ce992f375289670e595a2d1c15961aacbe0977407dfc",
+                "sha256:9f335e5625feb90e323d7e3868ec337f7b9ad88b5d633f876e3b778813021dab",
+                "sha256:b03fd10a1709d0101c054883b550f7c4c5e974f751e2680318759af005964990",
+                "sha256:b0ca2c60d3966dfd6608f5f8c49b8a0fcf76de6654f2eda55fc6ef038d5a6f27",
+                "sha256:b2604c6450f9dd2c42e223b1f5dca9643a23cfecc9fde4a94bb38e0d2693b136",
+                "sha256:ca0e7a658fbafcddcaefaa07ba8dae9384be2343468a8e011061791588d839fa",
+                "sha256:d0e9ac04065a814d4cf2c6791a2ad563f739ae3ae830d716d54245c2b96fead6",
+                "sha256:d50e8c1e571ee39b5dfbc295c11ad65988879f68009dd281a6e1edbc2ff6c18c",
+                "sha256:d840adcad7354be6f2ec28d0706528b0026e4c3934cc6566b84eac18633eab1b",
+                "sha256:e0bbee6c2a5bf2a0017a9b5e397babb88f230e6f07c3cdff4a4c4bc75ed7c617",
+                "sha256:e5afe0a7ea0e3a7a257907060bee6724a6002b7eec55d0db16fd32409795f3e1",
+                "sha256:e68be81cd8c22b029924b6d0ee814c337c0e706b8d88495a617319e5dd5441c3",
+                "sha256:ec9be0f4826cdb3a3a517509dcc5f87f370251b76362051ab59e42b6b765f8c4",
+                "sha256:f04f97797df35e442ed09f529ad1235d1f1c0f30878e2fe09a2676b71a8801e0",
+                "sha256:f41e57ad63d336fe50d3a67bb8eaa26c09f6dda6a59f76777a99b8ccd8e26aec"
             ],
             "index": "pypi",
-            "version": "==1.23.4"
+            "version": "==3.6.2"
+        },
+        "networkx": {
+            "hashes": [
+                "sha256:230d388117af870fce5647a3c52401fcf753e94720e6ea6b4197a5355648885e",
+                "sha256:e435dfa75b1d7195c7b8378c3859f0445cd88c6b0375c181ed66823a9ceb7524"
+            ],
+            "index": "pypi",
+            "version": "==2.8.8"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:01dd17cbb340bf0fc23981e52e1d18a9d4050792e8fb8363cecbf066a84b827d",
+                "sha256:06005a2ef6014e9956c09ba07654f9837d9e26696a0470e42beedadb78c11b07",
+                "sha256:09b7847f7e83ca37c6e627682f145856de331049013853f344f37b0c9690e3df",
+                "sha256:0aaee12d8883552fadfc41e96b4c82ee7d794949e2a7c3b3a7201e968c7ecab9",
+                "sha256:0cbe9848fad08baf71de1a39e12d1b6310f1d5b2d0ea4de051058e6e1076852d",
+                "sha256:1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a",
+                "sha256:33161613d2269025873025b33e879825ec7b1d831317e68f4f2f0f84ed14c719",
+                "sha256:5039f55555e1eab31124a5768898c9e22c25a65c1e0037f4d7c495a45778c9f2",
+                "sha256:522e26bbf6377e4d76403826ed689c295b0b238f46c28a7251ab94716da0b280",
+                "sha256:56e454c7833e94ec9769fa0f86e6ff8e42ee38ce0ce1fa4cbb747ea7e06d56aa",
+                "sha256:58f545efd1108e647604a1b5aa809591ccd2540f468a880bedb97247e72db387",
+                "sha256:5e05b1c973a9f858c74367553e236f287e749465f773328c8ef31abe18f691e1",
+                "sha256:7903ba8ab592b82014713c491f6c5d3a1cde5b4a3bf116404e08f5b52f6daf43",
+                "sha256:8969bfd28e85c81f3f94eb4a66bc2cf1dbdc5c18efc320af34bffc54d6b1e38f",
+                "sha256:92c8c1e89a1f5028a4c6d9e3ccbe311b6ba53694811269b992c0b224269e2398",
+                "sha256:9c88793f78fca17da0145455f0d7826bcb9f37da4764af27ac945488116efe63",
+                "sha256:a7ac231a08bb37f852849bbb387a20a57574a97cfc7b6cabb488a4fc8be176de",
+                "sha256:abdde9f795cf292fb9651ed48185503a2ff29be87770c3b8e2a14b0cd7aa16f8",
+                "sha256:af1da88f6bc3d2338ebbf0e22fe487821ea4d8e89053e25fa59d1d79786e7481",
+                "sha256:b2a9ab7c279c91974f756c84c365a669a887efa287365a8e2c418f8b3ba73fb0",
+                "sha256:bf837dc63ba5c06dc8797c398db1e223a466c7ece27a1f7b5232ba3466aafe3d",
+                "sha256:ca51fcfcc5f9354c45f400059e88bc09215fb71a48d3768fb80e357f3b457e1e",
+                "sha256:ce571367b6dfe60af04e04a1834ca2dc5f46004ac1cc756fb95319f64c095a96",
+                "sha256:d208a0f8729f3fb790ed18a003f3a57895b989b40ea4dce4717e9cf4af62c6bb",
+                "sha256:dbee87b469018961d1ad79b1a5d50c0ae850000b639bcb1b694e9981083243b6",
+                "sha256:e9f4c4e51567b616be64e05d517c79a8a22f3606499941d97bb76f2ca59f982d",
+                "sha256:f063b69b090c9d918f9df0a12116029e274daf0181df392839661c4c7ec9018a",
+                "sha256:f9a909a8bae284d46bbfdefbdd4a262ba19d3bc9921b1e76126b1d21c3c34135"
+            ],
+            "index": "pypi",
+            "version": "==1.23.5"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
         },
         "pandas": {
             "hashes": [
@@ -82,6 +310,81 @@
             ],
             "index": "pypi",
             "version": "==1.5.1"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:03150abd92771742d4a8cd6f2fa6246d847dcd2e332a18d0c15cc75bf6703040",
+                "sha256:073adb2ae23431d3b9bcbcff3fe698b62ed47211d0716b067385538a1b0f28b8",
+                "sha256:0b07fffc13f474264c336298d1b4ce01d9c5a011415b79d4ee5527bb69ae6f65",
+                "sha256:0b7257127d646ff8676ec8a15520013a698d1fdc48bc2a79ba4e53df792526f2",
+                "sha256:12ce4932caf2ddf3e41d17fc9c02d67126935a44b86df6a206cf0d7161548627",
+                "sha256:15c42fb9dea42465dfd902fb0ecf584b8848ceb28b41ee2b58f866411be33f07",
+                "sha256:18498994b29e1cf86d505edcb7edbe814d133d2232d256db8c7a8ceb34d18cef",
+                "sha256:1c7c8ae3864846fc95f4611c78129301e203aaa2af813b703c55d10cc1628535",
+                "sha256:22b012ea2d065fd163ca096f4e37e47cd8b59cf4b0fd47bfca6abb93df70b34c",
+                "sha256:276a5ca930c913f714e372b2591a22c4bd3b81a418c0f6635ba832daec1cbcfc",
+                "sha256:2e0918e03aa0c72ea56edbb00d4d664294815aa11291a11504a377ea018330d3",
+                "sha256:3033fbe1feb1b59394615a1cafaee85e49d01b51d54de0cbf6aa8e64182518a1",
+                "sha256:3168434d303babf495d4ba58fc22d6604f6e2afb97adc6a423e917dab828939c",
+                "sha256:32a44128c4bdca7f31de5be641187367fe2a450ad83b833ef78910397db491aa",
+                "sha256:3dd6caf940756101205dffc5367babf288a30043d35f80936f9bfb37f8355b32",
+                "sha256:40e1ce476a7804b0fb74bcfa80b0a2206ea6a882938eaba917f7a0f004b42502",
+                "sha256:41e0051336807468be450d52b8edd12ac60bebaa97fe10c8b660f116e50b30e4",
+                "sha256:4390e9ce199fc1951fcfa65795f239a8a4944117b5935a9317fb320e7767b40f",
+                "sha256:502526a2cbfa431d9fc2a079bdd9061a2397b842bb6bc4239bb176da00993812",
+                "sha256:51e0e543a33ed92db9f5ef69a0356e0b1a7a6b6a71b80df99f1d181ae5875636",
+                "sha256:57751894f6618fd4308ed8e0c36c333e2f5469744c34729a27532b3db106ee20",
+                "sha256:5d77adcd56a42d00cc1be30843d3426aa4e660cab4a61021dc84467123f7a00c",
+                "sha256:655a83b0058ba47c7c52e4e2df5ecf484c1b0b0349805896dd350cbc416bdd91",
+                "sha256:68943d632f1f9e3dce98908e873b3a090f6cba1cbb1b892a9e8d97c938871fbe",
+                "sha256:6c738585d7a9961d8c2821a1eb3dcb978d14e238be3d70f0a706f7fa9316946b",
+                "sha256:73bd195e43f3fadecfc50c682f5055ec32ee2c933243cafbfdec69ab1aa87cad",
+                "sha256:772a91fc0e03eaf922c63badeca75e91baa80fe2f5f87bdaed4280662aad25c9",
+                "sha256:77ec3e7be99629898c9a6d24a09de089fa5356ee408cdffffe62d67bb75fdd72",
+                "sha256:7db8b751ad307d7cf238f02101e8e36a128a6cb199326e867d1398067381bff4",
+                "sha256:801ec82e4188e935c7f5e22e006d01611d6b41661bba9fe45b60e7ac1a8f84de",
+                "sha256:82409ffe29d70fd733ff3c1025a602abb3e67405d41b9403b00b01debc4c9a29",
+                "sha256:828989c45c245518065a110434246c44a56a8b2b2f6347d1409c787e6e4651ee",
+                "sha256:829f97c8e258593b9daa80638aee3789b7df9da5cf1336035016d76f03b8860c",
+                "sha256:871b72c3643e516db4ecf20efe735deb27fe30ca17800e661d769faab45a18d7",
+                "sha256:89dca0ce00a2b49024df6325925555d406b14aa3efc2f752dbb5940c52c56b11",
+                "sha256:90fb88843d3902fe7c9586d439d1e8c05258f41da473952aa8b328d8b907498c",
+                "sha256:97aabc5c50312afa5e0a2b07c17d4ac5e865b250986f8afe2b02d772567a380c",
+                "sha256:9aaa107275d8527e9d6e7670b64aabaaa36e5b6bd71a1015ddd21da0d4e06448",
+                "sha256:9f47eabcd2ded7698106b05c2c338672d16a6f2a485e74481f524e2a23c2794b",
+                "sha256:a0a06a052c5f37b4ed81c613a455a81f9a3a69429b4fd7bb913c3fa98abefc20",
+                "sha256:ab388aaa3f6ce52ac1cb8e122c4bd46657c15905904b3120a6248b5b8b0bc228",
+                "sha256:ad58d27a5b0262c0c19b47d54c5802db9b34d38bbf886665b626aff83c74bacd",
+                "sha256:ae5331c23ce118c53b172fa64a4c037eb83c9165aba3a7ba9ddd3ec9fa64a699",
+                "sha256:af0372acb5d3598f36ec0914deed2a63f6bcdb7b606da04dc19a88d31bf0c05b",
+                "sha256:afa4107d1b306cdf8953edde0534562607fe8811b6c4d9a486298ad31de733b2",
+                "sha256:b03ae6f1a1878233ac620c98f3459f79fd77c7e3c2b20d460284e1fb370557d4",
+                "sha256:b0915e734b33a474d76c28e07292f196cdf2a590a0d25bcc06e64e545f2d146c",
+                "sha256:b4012d06c846dc2b80651b120e2cdd787b013deb39c09f407727ba90015c684f",
+                "sha256:b472b5ea442148d1c3e2209f20f1e0bb0eb556538690fa70b5e1f79fa0ba8dc2",
+                "sha256:b59430236b8e58840a0dfb4099a0e8717ffb779c952426a69ae435ca1f57210c",
+                "sha256:b90f7616ea170e92820775ed47e136208e04c967271c9ef615b6fbd08d9af0e3",
+                "sha256:b9a65733d103311331875c1dca05cb4606997fd33d6acfed695b1232ba1df193",
+                "sha256:bac18ab8d2d1e6b4ce25e3424f709aceef668347db8637c2296bcf41acb7cf48",
+                "sha256:bca31dd6014cb8b0b2db1e46081b0ca7d936f856da3b39744aef499db5d84d02",
+                "sha256:be55f8457cd1eac957af0c3f5ece7bc3f033f89b114ef30f710882717670b2a8",
+                "sha256:c7025dce65566eb6e89f56c9509d4f628fddcedb131d9465cacd3d8bac337e7e",
+                "sha256:c935a22a557a560108d780f9a0fc426dd7459940dc54faa49d83249c8d3e760f",
+                "sha256:dbb8e7f2abee51cef77673be97760abff1674ed32847ce04b4af90f610144c7b",
+                "sha256:e6ea6b856a74d560d9326c0f5895ef8050126acfdc7ca08ad703eb0081e82b74",
+                "sha256:ebf2029c1f464c59b8bdbe5143c79fa2045a581ac53679733d3a91d400ff9efb",
+                "sha256:f1ff2ee69f10f13a9596480335f406dd1f70c3650349e2be67ca3139280cade0"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==9.3.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+            ],
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
         },
         "pysimplegui": {
             "hashes": [
@@ -178,7 +481,7 @@
                 "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
                 "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "markers": "sys_platform == 'win32'",
             "version": "==0.4.6"
         },
         "debugpy": {
@@ -223,11 +526,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a",
-                "sha256:73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2"
+                "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828",
+                "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.0.1"
+            "version": "==1.0.4"
         },
         "executing": {
             "hashes": [
@@ -253,11 +556,11 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:301fdb487587c9bf277025001da97b53697aab73ae1268d9d1ba972a2c5fc801",
-                "sha256:e195cf6d8c3dd5d41f3cf8ad831d9891f95d7d18fa6d5fb4d30a713df99b26a4"
+                "sha256:3a9a1b2ad6dbbd5879855aabb4557f08e63fa2208bffed897f03070e2bb436f6",
+                "sha256:e178c1788399f93a459c241fe07c3b810771c607b1fb064a99d2c5d40c90c5d4"
             ],
             "index": "pypi",
-            "version": "==6.17.0"
+            "version": "==6.17.1"
         },
         "ipython": {
             "hashes": [
@@ -277,19 +580,19 @@
         },
         "jupyter-client": {
             "hashes": [
-                "sha256:1c1d418ef32a45a1fae0b243e6f01cc9bf65fa8ddbd491a034b9ba6ac6502951",
-                "sha256:5616db609ac720422e6a4b893d6572b8d655ff41e058367f4459a0d2c0726832"
+                "sha256:330f6b627e0b4bf2f54a3a0dd9e4a22d2b649c8518168afedce2c96a1ceb2860",
+                "sha256:df56ae23b8e1da1b66f89dee1368e948b24a7f780fa822c5735187589fc4c157"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.4.4"
+            "version": "==7.4.7"
         },
         "jupyter-core": {
             "hashes": [
-                "sha256:3815e80ec5272c0c19aad087a0d2775df2852cfca8f5a17069e99c9350cecff8",
-                "sha256:c2909b9bc7dca75560a6c5ae78c34fd305ede31cd864da3c0d0bb2ed89aa9337"
+                "sha256:4ed68b7c606197c7e344a24b7195eef57898157075a69655a886074b6beb7043",
+                "sha256:6da1fae48190da8551e1b5dbbb19d51d00b079d59a073c7030407ecaf96dbb1e"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.11.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==5.0.0"
         },
         "matplotlib-inline": {
             "hashes": [
@@ -332,11 +635,11 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93",
-                "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"
+                "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5",
+                "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.10.1"
+            "version": "==0.10.2"
         },
         "pickleshare": {
             "hashes": [
@@ -347,11 +650,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb",
-                "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"
+                "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
+                "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.3"
+            "version": "==2.5.4"
         },
         "pluggy": {
             "hashes": [
@@ -538,10 +841,10 @@
         },
         "stack-data": {
             "hashes": [
-                "sha256:8e515439f818efaa251036af72d89e4026e2b03993f3453c000b200fb4f2d6aa",
-                "sha256:b92d206ef355a367d14316b786ab41cb99eb453a21f2cb216a4204625ff7bc07"
+                "sha256:6c9a10eb5f342415fe085db551d673955611afb821551f554d91772415464315",
+                "sha256:960cb054d6a1b2fdd9cbd529e365b3c163e8dabf1272e02cfe36b58403cff5c6"
             ],
-            "version": "==0.6.0"
+            "version": "==0.6.1"
         },
         "tomli": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f19ff89434a7abd2ca8a4ae89343371dc7f1ed5b3a5538eaca497d4b924737d4"
+            "sha256": "4fc7cbe331b857ea1af1e8c8b4da0160f154fd720b0c5aa0c112a6e7d1fcf5b5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -106,6 +106,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==4.38.0"
+        },
+        "graphviz": {
+            "hashes": [
+                "sha256:587c58a223b51611c0cf461132da386edd896a029524ca61a1462b880bf97977",
+                "sha256:8c58f14adaa3b947daf26c19bc1e98c4e0702cdc31cf99153e6f06904d492bf8"
+            ],
+            "index": "pypi",
+            "version": "==0.20.1"
         },
         "kiwisolver": {
             "hashes": [
@@ -378,6 +386,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==9.3.0"
         },
+        "pydot": {
+            "hashes": [
+                "sha256:248081a39bcb56784deb018977e428605c1c758f10897a339fce1dd728ff007d",
+                "sha256:66c98190c65b8d2e2382a441b4c0edfdb4f4c025ef9cb9874de478fb0793a451"
+            ],
+            "index": "pypi",
+            "version": "==1.4.2"
+        },
         "pyparsing": {
             "hashes": [
                 "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
@@ -408,6 +424,33 @@
                 "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
             ],
             "version": "==2022.6"
+        },
+        "scipy": {
+            "hashes": [
+                "sha256:06d2e1b4c491dc7d8eacea139a1b0b295f74e1a1a0f704c375028f8320d16e31",
+                "sha256:0d54222d7a3ba6022fdf5773931b5d7c56efe41ede7f7128c7b1637700409108",
+                "sha256:1884b66a54887e21addf9c16fb588720a8309a57b2e258ae1c7986d4444d3bc0",
+                "sha256:1a72d885fa44247f92743fc20732ae55564ff2a519e8302fb7e18717c5355a8b",
+                "sha256:2318bef588acc7a574f5bfdff9c172d0b1bf2c8143d9582e05f878e580a3781e",
+                "sha256:4db5b30849606a95dcf519763dd3ab6fe9bd91df49eba517359e450a7d80ce2e",
+                "sha256:545c83ffb518094d8c9d83cce216c0c32f8c04aaf28b92cc8283eda0685162d5",
+                "sha256:5a04cd7d0d3eff6ea4719371cbc44df31411862b9646db617c99718ff68d4840",
+                "sha256:5b88e6d91ad9d59478fafe92a7c757d00c59e3bdc3331be8ada76a4f8d683f58",
+                "sha256:68239b6aa6f9c593da8be1509a05cb7f9efe98b80f43a5861cd24c7557e98523",
+                "sha256:83b89e9586c62e787f5012e8475fbb12185bafb996a03257e9675cd73d3736dd",
+                "sha256:83c06e62a390a9167da60bedd4575a14c1f58ca9dfde59830fc42e5197283dab",
+                "sha256:90453d2b93ea82a9f434e4e1cba043e779ff67b92f7a0e85d05d286a3625df3c",
+                "sha256:abaf921531b5aeaafced90157db505e10345e45038c39e5d9b6c7922d68085cb",
+                "sha256:b41bc822679ad1c9a5f023bc93f6d0543129ca0f37c1ce294dd9d386f0a21096",
+                "sha256:c68db6b290cbd4049012990d7fe71a2abd9ffbe82c0056ebe0f01df8be5436b0",
+                "sha256:cff3a5295234037e39500d35316a4c5794739433528310e117b8a9a0c76d20fc",
+                "sha256:d01e1dd7b15bd2449c8bfc6b7cc67d630700ed655654f0dfcf121600bad205c9",
+                "sha256:d644a64e174c16cb4b2e41dfea6af722053e83d066da7343f333a54dae9bc31c",
+                "sha256:da8245491d73ed0a994ed9c2e380fd058ce2fa8a18da204681f2fe1f57f98f95",
+                "sha256:fbc5c05c85c1a02be77b1ff591087c83bc44579c6d2bd9fb798bb64ea5e1a027"
+            ],
+            "index": "pypi",
+            "version": "==1.9.3"
         },
         "six": {
             "hashes": [
@@ -481,7 +524,7 @@
                 "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
                 "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
             ],
-            "markers": "sys_platform == 'win32'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
             "version": "==0.4.6"
         },
         "debugpy": {
@@ -572,11 +615,11 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d",
-                "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"
+                "sha256:203c1fd9d969ab8f2119ec0a3342e0b49910045abe6af0a3ae83a5764d54639e",
+                "sha256:bae794c30d07f6d910d32a7048af09b5a39ed740918da923c6b780790ebac612"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.18.1"
+            "version": "==0.18.2"
         },
         "jupyter-client": {
             "hashes": [
@@ -666,11 +709,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:24becda58d49ceac4dc26232eb179ef2b21f133fecda7eed6018d341766ed76e",
-                "sha256:e7f2129cba4ff3b3656bbdda0e74ee00d2f874a8bcdb9dd16f5fec7b3e173cae"
+                "sha256:535c29c31216c77302877d5120aef6c94ff573748a5b5ca5b1b1f76f5e700c73",
+                "sha256:ced598b222f6f4029c0800cefaa6a17373fb580cd093223003475ce32805c35b"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==3.0.32"
+            "version": "==3.0.33"
         },
         "psutil": {
             "hashes": [

--- a/engine/game_engine.py
+++ b/engine/game_engine.py
@@ -143,7 +143,7 @@ class GameEngine:
 
             sims = self.update_sims(sims)
 
-            self.draw_board()
+            print(self.draw_board())
 
         print(self.get_game_scores())
         game_log = pd.DataFrame(self.deep_game_log)

--- a/engine/game_engine.py
+++ b/engine/game_engine.py
@@ -62,7 +62,7 @@ class GameEngine:
             [list]: List of: list of legal actions
         """
         legal_actions = self.game.get_available_actions(special_policy)
-        return legal_actions
+        return legal_actions, self.get_current_player()
 
     def update_game_with_action(
         self, action_to_record: str, current_player: int
@@ -109,7 +109,7 @@ class GameEngine:
         # self.turn_log["Score"] = scores[current_player]
         self.game_log.append(self.turn_log)
 
-    def play_game_by_turns(self, sims) -> None:
+    def play_game_by_turns(self, sims: int) -> None:
         """
         Intializes Monte Carlo engine
         Will play a single game until game over condition is met

--- a/engine/game_engine.py
+++ b/engine/game_engine.py
@@ -146,6 +146,7 @@ class GameEngine:
             print(self.draw_board())
 
         print(self.get_game_scores())
+        # self.montecarlo.tree.draw_graph()
         game_log = pd.DataFrame(self.deep_game_log)
 
         timestamp = datetime.now().strftime("%m%d%Y_%H%M%S")

--- a/engine/monte_carlo_node.py
+++ b/engine/monte_carlo_node.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 import numpy as np
 
-
-class MonteCarloNode:
+class MonteCarloNode():
     def __init__(
-        self, parent: MonteCarloNode =None, node_action=None, label="Root Node", depth=0, player=None
+        self, parent: MonteCarloNode =None, node_action=None, label="Root Node", depth=0, player=None, game_state: tuple = None, game_image: str = None
     ):  # , legal_actions=None
         """
         Initializes monte carlo node
@@ -25,6 +24,14 @@ class MonteCarloNode:
         self.label = label  # label for the node, is used in GUI reporting
         self.depth = depth  # depth of the node
         self.player_owner = player  # the player who owns/plays this node layer. Should be same player at any given depth.
+        self.game_state = game_state
+        self.game_image = game_image
+
+    def get_game_state(self) -> tuple:
+        return self.game_state
+
+    def get_game_image(self) -> str:
+        return self.game_image
 
     def get_children(self) -> list[MonteCarloNode]:
         return self.children

--- a/engine/monte_carlo_node.py
+++ b/engine/monte_carlo_node.py
@@ -3,7 +3,7 @@ import numpy as np
 
 class MonteCarloNode():
     def __init__(
-        self, parent: MonteCarloNode =None, node_action=None, label="Root Node", depth=0, player=None, game_state: tuple = None, game_image: str = None
+        self, label="Root Node", depth=0, player=None, game_state: tuple = None, game_image: str = None
     ):  # , legal_actions=None
         """
         Initializes monte carlo node
@@ -16,68 +16,34 @@ class MonteCarloNode():
             player (int, optional): Player ID of node owner. Defaults to None.
         """
 
-        self.parent = parent  # the node that spawned this node. Root is None.
-        self.node_action = node_action  # the action being taken at this node
-        self.children: list[MonteCarloNode] = []  # the storage for the children of this node
-        self.number_of_visits = 0  # number of times current node is visited
-        self.total_score = 0  # total score for this node ONLY for its owner
-        self.label = label  # label for the node, is used in GUI reporting
-        self.depth = depth  # depth of the node
-        self.player_owner = player  # the player who owns/plays this node layer. Should be same player at any given depth.
-        self.game_state = game_state
-        self.game_image = game_image
+        self._number_of_visits = 0  # number of times current node is visited
+        self._total_score = 0  # total score for this node ONLY for its owner
+        self._label = label  # label for the node, is used in GUI reporting
+        self._depth = depth  # depth of the node
+        self._player_owner = player  # the player who owns/plays this node layer. Should be same player at any given depth.
+        self._game_state = game_state
+        self._game_image = game_image
+
+    def add_to_visits(self, visits_to_add: int):
+        self._number_of_visits += visits_to_add
+
+    def get_node_owner(self):
+        return self._player_owner
+
+    def add_to_score(self, points_to_add: float):
+        self._total_score += points_to_add
+
+    def get_total_score(self) -> float:
+        return self._total_score
+
+    def get_depth(self) -> int:
+        return self._depth
+
+    def get_visit_count(self) -> int:
+        return self._number_of_visits
 
     def get_game_state(self) -> tuple:
-        return self.game_state
+        return self._game_state
 
     def get_game_image(self) -> str:
-        return self.game_image
-
-    def get_children(self) -> list[MonteCarloNode]:
-        return self.children
-
-    def get_action(self):
-        return self.node_action
-
-    def get_parents(self):
-        return self.parent
-
-    def get_ancestors(self) -> set[MonteCarloNode]:
-        ancestor_list: list[MonteCarloNode] = [self]
-        if self.parent is not None:
-            ancestor_list += self.parent.get_ancestors()
-        return set(ancestor_list)
-
-    def best_child(self, explore_param=1.414, real_move=False) -> MonteCarloNode:
-        """
-        Evaluates all available children for highest scoring child node
-        first param is exploitation and second is exploration
-
-        Args:
-            explore_param (int, optional): Exploration term. Defaults to root 2.
-
-        Returns:
-            child node (object instance): MonteCarloNode object instance
-        """
-        choices_weights = []  # makes a list to store the score calculations
-        explore_param = 5
-        for child in self.get_children():
-            try:
-                # get scores of all child nodes
-                if real_move:
-                    score = child.total_score / child.number_of_visits
-                else:
-                    score = (
-                        child.total_score / child.number_of_visits
-                    ) + explore_param * (
-                        np.sqrt(np.log(self.number_of_visits) / child.number_of_visits)
-                    )
-                choices_weights.append(score)
-            except:
-                # if calculation runs into a divide by 0 error because child has never been visted
-                score = 1000
-                choices_weights.append(1000)
-
-        return self.get_children()[
-            np.argmax(choices_weights)
-        ]  # gets index of max score and sends back identity of child
+        return self._game_image

--- a/engine/monte_carlo_node.py
+++ b/engine/monte_carlo_node.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import numpy as np
+
 
 class MonteCarloNode():
     def __init__(

--- a/engine/monte_carlo_tree.py
+++ b/engine/monte_carlo_tree.py
@@ -56,7 +56,7 @@ class MonteCarloTree(nx.DiGraph):
         ]
 
     def get_best_child(
-        self, parent_node: MonteCarloNode, real_move=False
+        self, parent_node: MonteCarloNode, explore_param=1.414, real_move=False
     ) -> MonteCarloNode:
         choices_weights = []  # makes a list to store the score calculations
         explore_param = 5

--- a/engine/monte_carlo_tree.py
+++ b/engine/monte_carlo_tree.py
@@ -63,7 +63,7 @@ class MonteCarloTree(nx.DiGraph):
             try:
                 # get scores of all child nodes
                 if real_move:
-                    score = child.get_total_score() / child.get_visit_count()
+                    score = child.get_visit_count()
                 else:
                     score = (
                         child.get_total_score() / child.get_visit_count()
@@ -76,9 +76,10 @@ class MonteCarloTree(nx.DiGraph):
                 choices_weights.append(score)
             except:
                 # if calculation runs into a divide by 0 error because child has never been visted
-                score = 1000
-                choices_weights.append(1000)
-
+                score = 1e6
+                choices_weights.append(1e6)
+        if max(choices_weights) > 1e6:
+            pass
         return self.get_children(parent_node)[np.argmax(choices_weights)]
 
     def get_action(

--- a/engine/monte_carlo_tree.py
+++ b/engine/monte_carlo_tree.py
@@ -5,9 +5,10 @@ from networkx.drawing.nx_pydot import graphviz_layout
 from engine.monte_carlo_node import MonteCarloNode
 import numpy as np
 
-IMAGE = 'image'
-MC_NODE = 'mc_node'
-ACTION_ID = 'action_id'
+IMAGE = "image"
+MC_NODE = "mc_node"
+ACTION_ID = "action_id"
+
 
 class MonteCarloTree(nx.DiGraph):
     def draw_graph(self):
@@ -15,36 +16,63 @@ class MonteCarloTree(nx.DiGraph):
         nx.draw(self, pos=pos, with_labels=True)
         plt.show()
 
-    def add_node(self, new_node: MonteCarloNode):
-        self.add_node(new_node.get_game_state(), {IMAGE: new_node.get_game_image(), MC_NODE: new_node})
+    def add_mc_node(self, new_node: MonteCarloNode):
+        self.add_nodes_from(
+            [
+                (
+                    new_node.get_game_state(),
+                    {IMAGE: new_node.get_game_image(), MC_NODE: new_node},
+                )
+            ]
+        )
 
-    def add_child_node(self, parent_node: MonteCarloNode, child_node: MonteCarloNode, action):
+    def add_child_node(
+        self, parent_node: MonteCarloNode, child_node: MonteCarloNode, action
+    ):
         if child_node not in self:
-            self.add_node(child_node)
-        self.add_edge(parent_node.get_game_state(), child_node.get_game_state(), {ACTION_ID: action})
+            self.add_mc_node(child_node)
+        self.add_edge(
+            parent_node.get_game_state(),
+            child_node.get_game_state(),
+            node_action=action,
+        )
 
     def get_ancestors(self, node: MonteCarloNode) -> list[MonteCarloNode]:
-        return [self.nodes[ancestor][MC_NODE] for ancestor in nx.ancestors(self, node.get_game_state())]
+        return [
+            self.nodes[ancestor][MC_NODE]
+            for ancestor in nx.ancestors(self, node.get_game_state())
+        ]
 
     def get_children(self, parent_node: MonteCarloNode) -> list[MonteCarloNode]:
-        return [self.nodes[child][MC_NODE] for child in self.successors(parent_node.get_game_state())]
+        return [
+            self.nodes[child][MC_NODE]
+            for child in self.successors(parent_node.get_game_state())
+        ]
 
     def get_parents(self, child_node: MonteCarloNode) -> list[MonteCarloNode]:
-        return [self.nodes[parent][MC_NODE] for parent in self.predecessors(child_node.get_game_state())]
+        return [
+            self.nodes[parent][MC_NODE]
+            for parent in self.predecessors(child_node.get_game_state())
+        ]
 
-    def get_best_child(self, parent_node: MonteCarloNode, real_move=False) -> MonteCarloNode:
+    def get_best_child(
+        self, parent_node: MonteCarloNode, real_move=False
+    ) -> MonteCarloNode:
         choices_weights = []  # makes a list to store the score calculations
         explore_param = 5
         for child in self.get_children(parent_node):
             try:
                 # get scores of all child nodes
                 if real_move:
-                    score = child.total_score / child.number_of_visits
+                    score = child.get_total_score() / child.get_visit_count()
                 else:
                     score = (
-                        child.total_score / child.number_of_visits
+                        child.get_total_score() / child.get_visit_count()
                     ) + explore_param * (
-                        np.sqrt(np.log(parent_node.number_of_visits) / child.number_of_visits)
+                        np.sqrt(
+                            np.log(parent_node.get_visit_count())
+                            / child.get_visit_count()
+                        )
                     )
                 choices_weights.append(score)
             except:
@@ -52,8 +80,11 @@ class MonteCarloTree(nx.DiGraph):
                 score = 1000
                 choices_weights.append(1000)
 
-        return self.get_children(parent_node)[
-            np.argmax(choices_weights)]
+        return self.get_children(parent_node)[np.argmax(choices_weights)]
 
-    def get_action(self, parent_node: MonteCarloNode, child_node: MonteCarloNode) -> str:
-        return self[parent_node.get_game_state()][child_node.get_game_state()][ACTION_ID]
+    def get_action(
+        self, parent_node: MonteCarloNode, child_node: MonteCarloNode
+    ) -> str:
+        return self[parent_node.get_game_state()][child_node.get_game_state()][
+            "node_action"
+        ]

--- a/engine/monte_carlo_tree.py
+++ b/engine/monte_carlo_tree.py
@@ -88,3 +88,7 @@ class MonteCarloTree(nx.DiGraph):
             "node_action"
         ]
 
+    def get_nodes_path(self, parent: MonteCarloNode, child: MonteCarloNode) -> list[MonteCarloNode]:
+        shortest_path = nx.shortest_path(self, parent.get_game_state(), child.get_game_state())
+        return [self.nodes[node][MC_NODE] for node in shortest_path]
+

--- a/engine/monte_carlo_tree.py
+++ b/engine/monte_carlo_tree.py
@@ -1,7 +1,8 @@
 import networkx as nx
-import matplotlib.pyplot as plt
+import pylab as plt
+
+# from networkx.drawing.nx_agraph import write_dot, graphviz_layout
 import networkx as nx
-from networkx.drawing.nx_pydot import graphviz_layout
 from engine.monte_carlo_node import MonteCarloNode
 import numpy as np
 
@@ -12,8 +13,7 @@ ACTION_ID = "action_id"
 
 class MonteCarloTree(nx.DiGraph):
     def draw_graph(self):
-        pos = graphviz_layout(self, prog="dot")
-        nx.draw(self, pos=pos, with_labels=True)
+        nx.draw(self, with_labels=False, arrows=True)
         plt.show()
 
     def add_mc_node(self, new_node: MonteCarloNode):
@@ -29,7 +29,7 @@ class MonteCarloTree(nx.DiGraph):
     def add_child_node(
         self, parent_node: MonteCarloNode, child_node: MonteCarloNode, action
     ):
-        if child_node not in self:
+        if child_node.get_game_state() not in self:
             self.add_mc_node(child_node)
         self.add_edge(
             parent_node.get_game_state(),
@@ -59,7 +59,6 @@ class MonteCarloTree(nx.DiGraph):
         self, parent_node: MonteCarloNode, explore_param=1.414, real_move=False
     ) -> MonteCarloNode:
         choices_weights = []  # makes a list to store the score calculations
-        explore_param = 5
         for child in self.get_children(parent_node):
             try:
                 # get scores of all child nodes
@@ -88,3 +87,4 @@ class MonteCarloTree(nx.DiGraph):
         return self[parent_node.get_game_state()][child_node.get_game_state()][
             "node_action"
         ]
+

--- a/engine/monte_carlo_tree.py
+++ b/engine/monte_carlo_tree.py
@@ -1,0 +1,59 @@
+import networkx as nx
+import matplotlib.pyplot as plt
+import networkx as nx
+from networkx.drawing.nx_pydot import graphviz_layout
+from engine.monte_carlo_node import MonteCarloNode
+import numpy as np
+
+IMAGE = 'image'
+MC_NODE = 'mc_node'
+ACTION_ID = 'action_id'
+
+class MonteCarloTree(nx.DiGraph):
+    def draw_graph(self):
+        pos = graphviz_layout(self, prog="dot")
+        nx.draw(self, pos=pos, with_labels=True)
+        plt.show()
+
+    def add_node(self, new_node: MonteCarloNode):
+        self.add_node(new_node.get_game_state(), {IMAGE: new_node.get_game_image(), MC_NODE: new_node})
+
+    def add_child_node(self, parent_node: MonteCarloNode, child_node: MonteCarloNode, action):
+        if child_node not in self:
+            self.add_node(child_node)
+        self.add_edge(parent_node.get_game_state(), child_node.get_game_state(), {ACTION_ID: action})
+
+    def get_ancestors(self, node: MonteCarloNode) -> list[MonteCarloNode]:
+        return [self.nodes[ancestor][MC_NODE] for ancestor in nx.ancestors(self, node.get_game_state())]
+
+    def get_children(self, parent_node: MonteCarloNode) -> list[MonteCarloNode]:
+        return [self.nodes[child][MC_NODE] for child in self.successors(parent_node.get_game_state())]
+
+    def get_parents(self, child_node: MonteCarloNode) -> list[MonteCarloNode]:
+        return [self.nodes[parent][MC_NODE] for parent in self.predecessors(child_node.get_game_state())]
+
+    def get_best_child(self, parent_node: MonteCarloNode, real_move=False) -> MonteCarloNode:
+        choices_weights = []  # makes a list to store the score calculations
+        explore_param = 5
+        for child in self.get_children(parent_node):
+            try:
+                # get scores of all child nodes
+                if real_move:
+                    score = child.total_score / child.number_of_visits
+                else:
+                    score = (
+                        child.total_score / child.number_of_visits
+                    ) + explore_param * (
+                        np.sqrt(np.log(parent_node.number_of_visits) / child.number_of_visits)
+                    )
+                choices_weights.append(score)
+            except:
+                # if calculation runs into a divide by 0 error because child has never been visted
+                score = 1000
+                choices_weights.append(1000)
+
+        return self.get_children(parent_node)[
+            np.argmax(choices_weights)]
+
+    def get_action(self, parent_node: MonteCarloNode, child_node: MonteCarloNode) -> str:
+        return self[parent_node.get_game_state()][child_node.get_game_state()][ACTION_ID]

--- a/games/base_game_object.py
+++ b/games/base_game_object.py
@@ -90,3 +90,13 @@ class BaseGameObject(ABC):
             draws game state
         """
         pass
+
+    @abstractmethod
+    def get_game_state(self) -> tuple:
+        """Hook #7
+        Requests the game client to return a tuple representing a completely unique game state.
+
+        Returns:
+            tuple: Game state.  Tuple must contain strings and integers (it will be hashed later)
+        """
+        pass

--- a/games/base_game_object.py
+++ b/games/base_game_object.py
@@ -100,3 +100,10 @@ class BaseGameObject(ABC):
             tuple: Game state.  Tuple must contain strings and integers (it will be hashed later)
         """
         pass
+
+    @abstractmethod
+    def update_game_state(self, game_state: tuple):
+        """Hook #8
+        Gives the game a game state, allowing a partially played game to be created.
+        tuple must be in the same format as the one returned in get_game_state
+        """

--- a/games/simple_array_game.py
+++ b/games/simple_array_game.py
@@ -11,13 +11,28 @@ class SimpleArrayGame(BaseGameObject):
     The score is the index of the column that was filled
 
     """
+    array_length = 5
 
     def __init__(self, player_count):
-        self.board = np.zeros((5, 5))
+        self.board = np.zeros((self.array_length, self.array_length))
         self.name = "array_test"
 
     def get_available_actions(self, special_policy: bool = False) -> list:
         return list([tuple(i) for i in (np.argwhere(self.board == 0))])
+
+    def get_game_state(self) -> tuple:
+        game_state = [row_col for row in self.board.tolist() for row_col in row]
+        return tuple(game_state)
+
+    def _to_tuple(self, incoming_list):
+        try:
+            return tuple(self._to_tuple(x) for x in incoming_list)
+        except TypeError:
+            return incoming_list
+
+    def update_game_state(self, game_state: tuple):
+        game_state = np.asarray(game_state)
+        self.board = np.reshape(game_state, (self.array_length, self.array_length))
 
     def get_current_player(self) -> int:
         return 0

--- a/games/tic_tac_toe.py
+++ b/games/tic_tac_toe.py
@@ -33,7 +33,22 @@ class TicTacToe(BaseGameObject):
         self.player_count = 2
 
     def get_game_state(self) -> tuple:
-        return (*self.positions, *self.scores, self.game_over, self.current_player_num)
+        return (
+            tuple(self.positions),
+            tuple(self.scores.values()),
+            (self.game_over),
+            (self.current_player_num),
+        )
+
+    def update_game_state(self, game_state: tuple):
+        (
+            self.positions,
+            temp_scores,
+            self.game_over,
+            self.current_player_num,
+        ) = game_state
+        self.positions = list(self.positions)
+        self.scores.update(zip(self.scores.keys(), temp_scores))
 
     def draw_board(self):
         """Just draw an ASCII board."""
@@ -44,7 +59,7 @@ class TicTacToe(BaseGameObject):
         _____
         {self.positions[6]}|{self.positions[7]}|{self.positions[8]}"""
 
-        return(self.board)
+        return self.board
 
     def make_move(self, pos: int, current_player_num: int):
         """Makes a move on the board and draws it"""

--- a/games/tic_tac_toe.py
+++ b/games/tic_tac_toe.py
@@ -32,6 +32,9 @@ class TicTacToe(BaseGameObject):
 
         self.player_count = 2
 
+    def get_game_state(self) -> tuple:
+        return (*self.positions, *self.scores, self.game_over, self.current_player_num)
+
     def draw_board(self):
         """Just draw an ASCII board."""
         self.board = f"""\n
@@ -41,7 +44,7 @@ class TicTacToe(BaseGameObject):
         _____
         {self.positions[6]}|{self.positions[7]}|{self.positions[8]}"""
 
-        print(self.board)
+        return(self.board)
 
     def make_move(self, pos: int, current_player_num: int):
         """Makes a move on the board and draws it"""

--- a/single_game.py
+++ b/single_game.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     # decay = args.__dict__["d"]
 
     game_name = 'tic_tac_toe'
-    sims = 100
+    sims = 1000
     player_count = 2
     verbose = True
     num_games = 1

--- a/single_game.py
+++ b/single_game.py
@@ -45,21 +45,21 @@ if __name__ == "__main__":
     """
 
     # Parse the arguments
-    # args = parseArguments()
+    args = parseArguments()
 
-    # game_name = args.__dict__["game"]
-    # sims = args.__dict__["s"]
-    # player_count = args.__dict__["p"]
-    # verbose = args.__dict__["v"]
-    # num_games = args.__dict__["g"]
-    # decay = args.__dict__["d"]
+    game_name = args.__dict__["game"]
+    sims = args.__dict__["s"]
+    player_count = args.__dict__["p"]
+    verbose = args.__dict__["v"]
+    num_games = args.__dict__["g"]
+    decay = args.__dict__["d"]
 
-    game_name = 'tic_tac_toe'
-    sims = 100
-    player_count = 2
-    verbose = True
-    num_games = 1
-    decay = None
+    # game_name = 'tic_tac_toe'
+    # sims = 100
+    # player_count = 2
+    # verbose = True
+    # num_games = 1
+    # decay = None
 
     print(
         f"Initializing game: {game_name}, # sims: {sims}, # player_count: {player_count}, verbose: {verbose}, num_games: {num_games}, decay: {decay}"

--- a/single_game.py
+++ b/single_game.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     # decay = args.__dict__["d"]
 
     game_name = 'tic_tac_toe'
-    sims = 1000
+    sims = 100
     player_count = 2
     verbose = True
     num_games = 1

--- a/single_game.py
+++ b/single_game.py
@@ -45,21 +45,21 @@ if __name__ == "__main__":
     """
 
     # Parse the arguments
-    args = parseArguments()
+    # args = parseArguments()
 
-    game_name = args.__dict__["game"]
-    sims = args.__dict__["s"]
-    player_count = args.__dict__["p"]
-    verbose = args.__dict__["v"]
-    num_games = args.__dict__["g"]
-    decay = args.__dict__["d"]
+    # game_name = args.__dict__["game"]
+    # sims = args.__dict__["s"]
+    # player_count = args.__dict__["p"]
+    # verbose = args.__dict__["v"]
+    # num_games = args.__dict__["g"]
+    # decay = args.__dict__["d"]
 
-    # game_name = 'tic_tac_toe'
-    # sims = 500
-    # player_count = 2
-    # verbose = True
-    # num_games = 1
-    # decay = None
+    game_name = 'tic_tac_toe'
+    sims = 100
+    player_count = 2
+    verbose = True
+    num_games = 1
+    decay = None
 
     print(
         f"Initializing game: {game_name}, # sims: {sims}, # player_count: {player_count}, verbose: {verbose}, num_games: {num_games}, decay: {decay}"

--- a/tests/test_azul.py
+++ b/tests/test_azul.py
@@ -109,7 +109,7 @@ def test_tower_avail(tower_w_tiles: azul.Tower, tile_dictionary_rybp_avail:azul.
     assert tower_w_tiles.get_available_tiles() == tile_dictionary_rybp_avail
 
 
-def test_add_tiles(tower_w_tiles:azul.Tower, tile_dictionary_ro: dict, tile_dictionary_both: dict):
+def test_add_tiles(tower_w_tiles: azul.Tower, tile_dictionary_ro: dict, tile_dictionary_both: dict):
     tower_w_tiles.add_tiles(tile_dictionary_ro)
     assert tower_w_tiles.get_available_tiles() == tile_dictionary_both
 

--- a/tests/test_game_engine.py
+++ b/tests/test_game_engine.py
@@ -1,15 +1,17 @@
 import pytest
+from engine import game_engine
+
 
 
 class TestGameEngine:
-    def test_engine(self, engine):
-        assert engine.simulations == 10
+    def test_engine(self, engine: game_engine.GameEngine):
+        assert engine.number_of_sims == 10
         assert engine.player_count == 3
         assert engine.verbose == True
 
-    def test_legal_actions(self, engine):
+    def test_legal_actions(self, engine: game_engine.GameEngine):
 
-        actions, player = engine.get_legal_actions(special_policy=False)
+        actions, player = engine.get_available_actions(special_policy=False)
         assert actions == [
             (0, 0),
             (0, 1),
@@ -39,13 +41,13 @@ class TestGameEngine:
         ]
         assert player == 0
 
-    def test_game_over(self, engine):
+    def test_game_over(self, engine: game_engine.GameEngine):
         game_over = engine.is_game_over()
         assert game_over == False
 
-    def test_update_game_with_action(self, engine):
+    def test_update_game_with_action(self, engine: game_engine.GameEngine):
         engine.update_game_with_action((0, 0), 0)
-        actions, player = engine.get_legal_actions(special_policy=False)
+        actions, player = engine.get_available_actions(special_policy=False)
         assert actions == [
             (0, 1),
             (0, 2),
@@ -78,7 +80,7 @@ class TestGameEngine:
     def test_get_game_scores(self):
         pass
 
-    def test_play_out_game(self, engine):
-        engine.play_game_by_turns()
+    def test_play_out_game(self, engine: game_engine.GameEngine):
+        engine.play_game_by_turns(sims=500)
         game_over = engine.is_game_over()
         assert game_over == True


### PR DESCRIPTION
All should be good now.
Major changes:
- Changed structure to tree, eliminating redundant nodes.  This added a `MonteCarloTree` object.
- Changed `select_rollout_node` to return a path of nodes (since now nodes have non-unique paths to the root)
- Changed `back_propagate` method to act on the node path rather than a node and it's ancestors
- Removed `deep_copy` calls.  Replaced with a save and load of game state
- Added get_game_state() and update_game_state() methods to both the `BaseGameObject` and `TicTacToe` classes
-Other changes to support these (removal of `self.game_copy`, addition of `self.game` to `game_engine`, etc.)